### PR TITLE
fix: add validation to prevent user go ahead without select any subtitle

### DIFF
--- a/src/prompts/Subtitles.ts
+++ b/src/prompts/Subtitles.ts
@@ -13,11 +13,19 @@ export async function SubtitlesPrompt(): Promise<unknown> {
     return subtitles;
   }
 
+  function validate(userInput: string[]): string | boolean {
+    if (!userInput || userInput.length < 1) {
+      return 'You must select at least one subtitle (use your space bar to do it)';
+    }
+    return true;
+  }
+
   return new PromptFactory<PromptCheckboxQuestion>({
     choices,
     name: 'subtitle',
     message: 'Choose all subtitles you want to download',
     filter,
     type: 'checkbox',
+    validate,
   }).ask();
 }

--- a/src/types/prompt.ts
+++ b/src/types/prompt.ts
@@ -7,6 +7,7 @@ export type PromptBaseQuestion = {
   type: PromptType;
   message: string;
   filter: PromptFilterFn;
+  validate?: (userSelection: any) => boolean | string;
 };
 
 export type ChoiceType = {


### PR DESCRIPTION
Currently its possible move forward to "download" subtitles if not having any selected.

Just introduce a validate param for this step.